### PR TITLE
removed yuicompress options because it is no longer suported by less >= 1.5.0-b1

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -126,15 +126,6 @@ module.exports = function(grunt) {
           'test/actual/nopaths.css': ['test/fixtures/nopaths.less']
         }
       },
-      yuicompress: {
-        options: {
-          paths: ['test/fixtures/include'],
-          yuicompress: true
-        },
-        files: {
-          'test/actual/yuicompress.css': ['test/fixtures/style.less']
-        }
-      },
       ieCompatTrue: {
         options: {
           paths: ['test/fixtures/include'],

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -160,16 +160,6 @@ module.exports = function(grunt) {
           'test/actual/compressReport.css': ['test/fixtures/style.less', 'test/fixtures/style2.less']
         }
       },
-      yuicompressReport: {
-        options: {
-          paths: ['test/fixtures/include'],
-          yuicompress: true,
-          report: 'gzip'
-        },
-        files: {
-          'test/actual/yuicompressReport.css': ['test/fixtures/style.less', 'test/fixtures/style2.less', 'test/fixtures/style3.less']
-        }
-      }
     },
 
     // Unit tests.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ A `.lessrc` file must contain valid JSON and look something like this:
 
 ```json
 {
-  "yuicompress": true,
+  "compress": true,
   "strictMath": true,
   "strictUnits": true,
   "paths": ["vendor/bootstrap/less"]
@@ -46,7 +46,7 @@ A `.lessrc` file must contain valid JSON and look something like this:
 A `.lessrc.yml` must contain valid YAML and look something like this:
 
 ```yaml
-yuicompress: true
+compress: true
 strictMath: true
 strictUnits: true
 paths:
@@ -163,12 +163,6 @@ Default: false
 
 Compress output by removing some whitespaces.
 
-#### yuicompress
-Type: `Boolean`
-Default: false
-
-Compress output using cssmin.js
-
 #### ieCompat
 Type: `Boolean`
 Default: true
@@ -244,7 +238,7 @@ less: {
   production: {
     options: {
       paths: ["assets/css"],
-      yuicompress: true
+      compress: true
     },
     files: {
       "path/to/result.css": "path/to/source.less"

--- a/docs/less-examples.md
+++ b/docs/less-examples.md
@@ -13,7 +13,7 @@ less: {
   production: {
     options: {
       paths: ["assets/css"],
-      yuicompress: true
+      compress: true
     },
     files: {
       "path/to/result.css": "path/to/source.less"

--- a/docs/less-options.md
+++ b/docs/less-options.md
@@ -10,7 +10,7 @@ A `.lessrc` file must contain valid JSON and look something like this:
 
 ```json
 {
-  "yuicompress": true,
+  "compress": true,
   "strictMath": true,
   "strictUnits": true,
   "paths": ["vendor/bootstrap/less"]
@@ -20,7 +20,7 @@ A `.lessrc` file must contain valid JSON and look something like this:
 A `.lessrc.yml` must contain valid YAML and look something like this:
 
 ```yaml
-yuicompress: true
+compress: true
 strictMath: true
 strictUnits: true
 paths:
@@ -136,12 +136,6 @@ Type: `Boolean`
 Default: false
 
 Compress output by removing some whitespaces.
-
-## yuicompress
-Type: `Boolean`
-Default: false
-
-Compress output using cssmin.js
 
 ## ieCompat
 Type: `Boolean`

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "less": "https://github.com/less/less.js/tarball/1.5.0-wip",
+    "less": "~1.5.0",
     "grunt-lib-contrib": "~0.6.1"
   },
   "devDependencies": {

--- a/tasks/less.js
+++ b/tasks/less.js
@@ -43,7 +43,6 @@ module.exports = function(grunt) {
         'silent',
         'verbose',
         'compress',
-        'yuicompress',
         'ieCompat',
         'strictMath',
         'strictUnits'
@@ -229,7 +228,6 @@ module.exports = function(grunt) {
     }
 
     var parser = new less.Parser(grunt.util._.pick(options, lessOptions.parse));
-
     parser.parse(srcCode, function(parse_err, tree) {
       if (parse_err) {
         lessError(parse_err);

--- a/test/less_test.js
+++ b/test/less_test.js
@@ -54,23 +54,6 @@ exports.less = {
 
     test.done();
   },
-  yuicompress: function(test) {
-    'use strict';
-
-    var actual, expected;
-
-    test.expect(2);
-
-    actual   = grunt.file.read('test/actual/yuicompress.css');
-    expected = grunt.file.read('test/expected/yuicompress.css');
-    test.equal(expected, actual, 'should yuicompress output when yuicompress option is true');
-
-    actual   = grunt.file.read('test/actual/yuicompressReport.css');
-    expected = grunt.file.read('test/expected/yuicompressReport.css');
-    test.equal(expected, actual, 'should yuicompress output when yuicompress option is true and concating is enable');
-
-    test.done();
-  },
   ieCompat: function(test) {
     'use strict';
 


### PR DESCRIPTION
updated less npm dependency and removed yui compression test, because it was removed in 'less v1.5.0-b1'
