### PR TITLE
Added urlArgs for cache busting for url tokens

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -173,6 +173,13 @@ Default: `false`
 
 Rewrite urls to be relative. false: do not modify urls.
 
+## urlArgs
+Type: `String`
+
+Default: none
+
+Appends string to url tokens for cache busting.
+
 ## customFunctions
 Type: `Object`
 

--- a/tasks/less.js
+++ b/tasks/less.js
@@ -62,7 +62,8 @@ module.exports = function(grunt) {
       'sourceMapRootpath',
       'sourceMapURL',
       'strictMath',
-      'strictUnits'
+      'strictUnits',
+      'urlArgs'
     ]
   };
 


### PR DESCRIPTION
In less.js 1.6.3 urlArgs has been added.

See the original pull request for more information: https://github.com/less/less.js/pull/1811
