### PR TITLE
fix less task overwriting grunt.config.data object

### DIFF
--- a/tasks/less.js
+++ b/tasks/less.js
@@ -224,7 +224,7 @@ module.exports = function(grunt) {
     // Read in metadata to pass to templates as context.
     var metadata = utils.readOptionsData(options.metadata, {namespace: true});
 
-    metadata = _.merge(grunt.config.data, metadata, grunt.task.current.data.options);
+    metadata = _.merge({}, grunt.config.data, metadata, grunt.task.current.data.options);
     metadata = grunt.config.process(metadata);
 
     if (options.process === true) {options.process = {};}


### PR DESCRIPTION
Commit 0729eeb5dd874233f93a9a613c9f7ebe18cea684 changed one call to
_.merge so it would overwrite the grunt.config.data object. This reverts
this one line accordingly.
# Problem

```
metadata = _.merge({}, grunt.config.data, metadata,
                   grunt.task.current.data.options);
```

_.merge (see [lodash documentation](http://lodash.com/docs#merge)) overwrites the
first argument, since this is used as the destination. Using just
a clean object as destination, _.merge will also return the destination
object and store this result into metadata.

Overwriting grunt.config.data is a big problem if the `less` task is
used in combination with other tasks like `compress` from the
grunt-contrib-compress library. There is a `compress` option for
assemble-less, that will be available in
`grunt.task.current.data.options`. Merging this into grunt.config.data
will then overwrite the configuration of the compress task (with `true`
in this case). Leading to a very strange error message from grunt, since
some kind of object is expected there.
